### PR TITLE
Updates to pretty-printer

### DIFF
--- a/lib/debugger.js
+++ b/lib/debugger.js
@@ -339,7 +339,7 @@ ast.Run.prototype._dump = function(dump_ctx, indent) {
 ast.Run.prototype._dump_word_list = function() {
    let word_list = ast.ASTNode.prototype._dump_word_list.call(this);
 
-   word_list.add((this.name ? this.name : "MODULE") + "-" +
+   word_list.add((this.name ? this.name : "MODULE") +
 		 this.module_instance_id);
 
    //

--- a/lib/debugger.js
+++ b/lib/debugger.js
@@ -447,6 +447,20 @@ ast.Exit.prototype._dump_word_list = function() {
    return word_list;
 }
 
+ast.CountExpressionNode.prototype._dump_word_list = function() {
+   let word_list = ast.ExpressionNode.prototype._dump_word_list.call(this);
+
+   if (this.func_count) {
+      if (this.accessor_list_count.length == 0) {
+        word_list.add_at(1, this.func_count());
+      } else {
+        word_list.add_at(1, "[Runtime count expression]");
+      }
+   }
+
+   return word_list;
+}
+
 //
 // Helper functions of the AST visit methods.
 //

--- a/lib/debugger.js
+++ b/lib/debugger.js
@@ -464,7 +464,14 @@ function dump_signal_decl_list_wd(word_list, signal_declaration_list) {
 	 }
       }
 
-      let word = word_list.add(sigdecl.name, DISP_FG_SIGNAL(present));
+      let sigil;
+      switch (sigdecl.accessibility) {
+         case hh.IN:  sigil = '-'; break;
+         case hh.OUT: sigil = '+'; break;
+         default:     sigil = '';  break;
+      }
+
+      let word = word_list.add(sigil + sigdecl.name, DISP_FG_SIGNAL(present));
       let v = sig.value;
       word.signal_value = v instanceof Object ? v.toString() : v;
    }


### PR DESCRIPTION
 - It now prints module names as MODULE0 instead of MODULE-0, so that uses match definitions.
 - For the signals declared at the top of a module, it prints + in front of output signals and - in front of input signals.
 - It prints the count that goes with expressions like "Await Count Signal" and "Every Count Signal Block".